### PR TITLE
docs: clarify documentation of uv_tcp_init_ex

### DIFF
--- a/docs/src/tcp.rst
+++ b/docs/src/tcp.rst
@@ -34,7 +34,7 @@ API
 
 .. c:function:: int uv_tcp_init_ex(uv_loop_t* loop, uv_tcp_t* handle, unsigned int flags)
 
-    Initialize the handle with the specified flags. At the moment the lower 8 bits
+    Initialize the handle with the specified flags. At the moment only the lower 8 bits
     of the `flags` parameter are used as the socket domain. A socket will be created
     for the given domain. If the specified domain is ``AF_UNSPEC`` no socket is created,
     just like :c:func:`uv_tcp_init`.


### PR DESCRIPTION
I think this makes it clear that the flags can't contain any other
information.

PR-URL: https://github.com/libuv/libuv/pull/592
Reviewed-By: Ben Noordhuis info@bnoordhuis.nl
